### PR TITLE
Matched/unmatched concepts in Intent Dictionaries

### DIFF
--- a/src/intent.html
+++ b/src/intent.html
@@ -301,7 +301,7 @@ S                  := [ \t\n\r]*
      and compared using <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>
      match.</p>
    <p>A concept is considered a <dfn id="intent_known_concept">known concept</dfn> (to the AT)
-     when the AT has any internal mapping recognizing that concept.
+     when the AT has any internal behavior recognizing that concept.
      It is also considered a <dfn id="intent_matched_concept"></dfn>matched concept</dfn> when
      its normalized name, the fixity property (which may be defaulted in the concept dictionary),
      and the arity (number of arguments, if any)
@@ -322,7 +322,7 @@ S                  := [ \t\n\r]*
      may also indicate different rendering choices.</p>
    <p>Otherwise, if the concept name, fixity and arity do not match it is considered to be an
      <dfn id="intent_unmatched_concept">unmatched concept</dfn> (to the dictionary).
-     If no additional mapping is available for that concept name,
+     If no additional behavior is available for that concept name,
      it is an <dfn id="intent_unknown_concept">unknown concept</dfn> (to the AT)
      and will be treated the same as a [=literal=];
      that is, the name is spoken as-is after normalizing each of `-`, `_` and `.` to an inter-word space.

--- a/src/intent.html
+++ b/src/intent.html
@@ -295,16 +295,17 @@ S                  := [ \t\n\r]*
    <h3 id="intent_using">Using Intent Concepts and Properties</h3>
    <p>When the <code class="attribute">intent</code> attribute corresponding to a specific node
      contains a concept component, possibly with properties and arguments,
-     the AT's [=Intent Concept Dictionary=] should be consulted.
+     the supported [=Intent Concept Dictionary=] entries should be consulted.
      The concept name should be normalized
      (<q>`_`</q> (U+00F5) and <q>`.`</q>  (U+002E) to <q>`-`</q> (U+002D)),
      and compared using <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>
      match.</p>
-   <p>An concept is considered a <dfn id="intent_known_concept">known concept</dfn> (to the AT)
-     when the normalized name,
-     the fixity property (which may be defaulted in the concept dictionary),
+   <p>A concept is considered a <dfn id="intent_known_concept">known concept</dfn> (to the AT)
+     when the AT has any internal mapping recognizing that concept.
+     It is also considered a <dfn id="intent_matched_concept"></dfn>matched concept</dfn> when
+     its normalized name, the fixity property (which may be defaulted in the concept dictionary),
      and the arity (number of arguments, if any)
-     all match an entry in the AT's concept dictionary.
+     all match an entry in the Core or Open concept dictionaries.
      The speech hint in the matching entry
      can be used be used as a guide for the generation of
      specific audio, replacement text or braille renderings, as appropriate.
@@ -320,7 +321,9 @@ S                  := [ \t\n\r]*
      Note that properties other than those specifying fixity
      may also indicate different rendering choices.</p>
    <p>Otherwise, if the concept name, fixity and arity do not match it is considered to be an
-     <dfn id="intent_unknown_concept">unknown concept</dfn> (to the AT)
+     <dfn id="intent_unmatched_concept">unmatched concept</dfn> (to the dictionary).
+     If no additional mapping is available for that concept name,
+     it is an <dfn id="intent_unknown_concept">unknown concept</dfn> (to the AT)
      and will be treated the same as a [=literal=];
      that is, the name is spoken as-is after normalizing each of `-`, `_` and `.` to an inter-word space.
      Even for an unknown concept, if a fixity property and arguments were given (or inferred),


### PR DESCRIPTION
This PR builds on https://github.com/w3c/mathml/pull/513 to clarify 
 - matched/unmatched concepts with respect to a Dictionary
 - known/unknown concepts with respect to an AT implementation

Motivation: The PR follows the design principle of remaining implementation-agnostic and allowing more room for AT experimentation.

Edit 1: Adding example
Edit 2: Adding brief discussion of rebuttals.

### Discussion summary

The PR author suggests that the spec text can expand the known/unknown categories to clearly cover more behaviors than the "dictionary matching" behavior, for alternative AT experimentation (such as unusual arity extensions, or neural models which do not contain a dictionary). The text does not need to describe these in any detail, as implementation is out-of-scope, but could hint at the provisions having been made for such approaches. 

Having "known concepts" that are not "matched" in the available lists is such a signal.

No new requirements are meant to be introduced here, the intention is the opposite - to expand to more possible implementation avenues. Rewording is most welcome to make that even clearer.

### Example of matched/unmatched vs known/unknown

Adding a helpful demonstration of the categories here.
For this example:

- AT 1 has an extension for 3 argument power, used for fractional exponents. 
  - AT 1 has also implemented all entries in the Core and Open dictionaries.
- AT 2 is a pre-university AT that only covers the Core dictionary.
  - AT 2 is temporarily missing a dedicated implementation for `power`, for sake of example.

Here are the 2x2 possibilities for intent values that have `power` as the expression head:

known/unknown | matched/unmatched | example intent | example speech
 :-- | :-- | :-- | :-- 
known to AT 1 | matched (Core) | `power($base,$degree)` | `$base` raised to the `$degree` power
known to AT 1 | unmatched (Core+Open) | `power($base,$degree,$root)` | `$base` raised to the fractional power `$degree` over `$root` end fractional power
unknown to AT 2 | matched (Core) | `power($base,$degree)` | power of `$base` and `$degree`
unknown to AT 2 | unmatched (Core) | `power($base,$degree,$root)` | power of `$base`, `$degree` and `$root`.

